### PR TITLE
Fix YAML in example

### DIFF
--- a/cs_storage_block.md
+++ b/cs_storage_block.md
@@ -1152,7 +1152,7 @@ Before you begin: [Log in to your account. If applicable, target the appropriate
            resources:
              requests:
                storage: 20Gi
-         storageClassName: ibmc-block-bronze-delayed
+           storageClassName: ibmc-block-bronze-delayed
        - metadata:
            name: myvol2
          spec:
@@ -1161,7 +1161,7 @@ Before you begin: [Log in to your account. If applicable, target the appropriate
            resources:
              requests:
                storage: 20Gi
-         storageClassName: ibmc-block-bronze-delayed
+           storageClassName: ibmc-block-bronze-delayed
      ```
      {: codeblock}
 


### PR DESCRIPTION
In https://cloud.ibm.com/docs/containers?topic=containers-block_storage#block_dynamic_statefulset under point nr. 2 in the example `Example stateful set with anti-affinity rule and delayed block storage creation:`, under ` sts.spec.volumeClaimTemplates.spec` the `storageClassName` entry is badly indented in both volumes.