### PR TITLE
Block Store Encryption - kubectl command fix

### DIFF
--- a/cs_storage_block.md
+++ b/cs_storage_block.md
@@ -811,7 +811,7 @@ The following steps explain how to create a custom, encrypted storage class that
 
   3. Create the storage class in your cluster.
     ```
-    kubectl storageclass.yaml
+    kubectl apply -f storageclass.yaml
     ```
     {: pre}
 


### PR DESCRIPTION
The block for applying the storageclass YAML for BYOK encryption doesn't have a proper `kubectl` command, added `apply -f`