### PR TITLE
Fix typo in concurrent worker replace note

### DIFF
--- a/cs_cluster_update.md
+++ b/cs_cluster_update.md
@@ -432,9 +432,7 @@ You VPC worker node is replaced by removing the old worker node and provisioning
 
 **What if I replace multiple worker nodes at the same time?**
 
-If you replace multiple worker nodes at the same ti**
-ey are deleted and replaced concurrently, not one by one. Make sure that you have enough capacity in your cluster to reschedule your workloads before you replace worker nodes.
-**
+If you replace multiple worker nodes at the same time **they are deleted and replaced concurrently, not one by one. Make sure that you have enough capacity in your cluster to reschedule your workloads before you replace worker nodes.**
 
 **What if a replacement worker node is not created?**
 


### PR DESCRIPTION
Hi all, just noticed this typo while sharing the doc. Hope this helps! 😄 