### PR TITLE
Removed Classic Infra from the title

### DIFF
--- a/edge.md
+++ b/edge.md
@@ -16,7 +16,7 @@ subcollection: containers
 
 
 
-# Restricting network traffic to edge worker nodes on classic infrastructure
+# Restricting network traffic to edge worker nodes
 {: #edge}
 
 Edge worker nodes can improve the security of your {{site.data.keyword.containerlong}} cluster by allowing fewer worker nodes by isolating the networking workload.


### PR DESCRIPTION
This topology applies to both VPC and Classic. So I suggest to remove Classic from the page title.